### PR TITLE
Moodle 4.1 fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
-name: Run all tests for Moodle 33+
+name: Run all tests
 
 on: [push, pull_request]
 
 jobs:
-  workflow_group_33_plus_ci:
-    uses: catalyst/catalyst-moodle-workflows/.github/workflows/group-33-plus-ci.yml@main
+  ci:
+    uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main

--- a/tests/admin_settings_aws_region_test.php
+++ b/tests/admin_settings_aws_region_test.php
@@ -23,9 +23,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace local_aws\tests;
-
-use local_aws\admin_settings_aws_region;
+namespace local_aws;
 
 /**
  * Testcase for the list of AWS regions admin setting.
@@ -34,8 +32,9 @@ use local_aws\admin_settings_aws_region;
  * @author     Mikhail Golenkov <mikhailgolenkov@catalyst-au.net>
  * @copyright  2020 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_aws\admin_settings_aws_region
  */
-class admin_settings_aws_region_testcase extends \advanced_testcase {
+class admin_settings_aws_region_test extends \advanced_testcase {
 
     /**
      * Test that output_html() method works and returns HTML string with expected content.

--- a/tests/aws_helper_test.php
+++ b/tests/aws_helper_test.php
@@ -21,9 +21,12 @@
  * @author    Peter Burnett <peterburnett@catalyst-au.net>
  * @copyright 2020 Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers    \local_aws\local\aws_helper
  */
 
-namespace local_aws\tests;
+namespace local_aws;
+
+use local_aws\local\aws_helper;
 
 /**
  * Testcase for the AWS helper.
@@ -33,25 +36,25 @@ namespace local_aws\tests;
  * @copyright  2020 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class aws_helper_testcase extends \advanced_testcase {
+class aws_helper_test extends \advanced_testcase {
 
     public function test_get_proxy_string() {
         global $CFG;
         $this->resetAfterTest();
         // Confirm with no config an empty string is returned.
         $CFG->proxyhost = '';
-        $this->assertEquals('', \local_aws\local\aws_helper::get_proxy_string());
+        $this->assertEquals('', aws_helper::get_proxy_string());
 
         // Now set some configs.
         $CFG->proxyhost = '127.0.0.1';
         $CFG->proxyuser = 'user';
         $CFG->proxypassword = 'password';
         $CFG->proxyport = '1337';
-        $this->assertEquals('user:password@127.0.0.1:1337', \local_aws\local\aws_helper::get_proxy_string());
+        $this->assertEquals('user:password@127.0.0.1:1337', aws_helper::get_proxy_string());
 
         // Now change to SOCKS proxy.
         $CFG->proxytype = 'SOCKS5';
-        $this->assertEquals('socks5://user:password@127.0.0.1:1337', \local_aws\local\aws_helper::get_proxy_string());
+        $this->assertEquals('socks5://user:password@127.0.0.1:1337', aws_helper::get_proxy_string());
     }
 
 }

--- a/tests/guzzle_helper_test.php
+++ b/tests/guzzle_helper_test.php
@@ -16,6 +16,10 @@
 
 namespace local_aws;
 
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/../sdk/aws-autoloader.php');
+
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -30,6 +34,7 @@ use local_aws\local\guzzle_helper;
  * @author     Andrew Madden <andrewmadden@catalyst-au.net>
  * @copyright  2023 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_aws\local\guzzle_helper
  */
 class guzzle_helper_test extends \advanced_testcase {
 

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023010900;
+$plugin->version   = 2023011100;
 $plugin->release   = '3.208.1'; // This should be in lock step with sdk/CHANGELOG.md.
 $plugin->requires  = 2013111811;
 $plugin->component = 'local_aws';


### PR DESCRIPTION
This resolves #50 and should confirm the plugin works with Moodle 4.1, although there may be issues found when testing a plugin that depends on this (e.g. objectfs).