### PR TITLE
issue #18 Add guzzle middleware to add proxy options when required

### DIFF
--- a/classes/local/aws_helper.php
+++ b/classes/local/aws_helper.php
@@ -73,7 +73,7 @@ class aws_helper {
      * @return AwsClient
      */
     public static function configure_client_proxy(AwsClient $client): AwsClient {
-        $client->getHandlerList()->appendBuild(self::get_callable_middleware(), 'proxy_bypass');
+        $client->getHandlerList()->appendBuild(self::add_proxy_when_required(), 'proxy_bypass');
         return $client;
     }
 
@@ -82,7 +82,7 @@ class aws_helper {
      *
      * @return callable Middleware high order callable.
      */
-    protected static function get_callable_middleware(): callable {
+    protected static function add_proxy_when_required(): callable {
         return function (callable $fn) {
             return function (CommandInterface $command, ?RequestInterface $request = null) use ($fn) {
                 if (isset($request)) {

--- a/classes/local/guzzle_helper.php
+++ b/classes/local/guzzle_helper.php
@@ -1,0 +1,59 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_aws\local;
+
+use GuzzleHttp\Client;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Guzzle helper class. Provides useful middleware such as preparing proxies.
+ *
+ * @package    local_aws
+ * @author     Andrew Madden <andrewmadden@catalyst-au.net>
+ * @copyright  2022 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class guzzle_helper {
+
+    /**
+     * Add additional configuration to the Guzzle client. For example, adding additional Middleware.
+     *
+     * @param Client $client
+     * @return Client
+     */
+    public static function configure_client_proxy(Client $client): Client {
+        $client->getConfig('handler')->push(self::add_proxy_when_required(), 'proxy');
+        return $client;
+    }
+
+    /**
+     * Middleware that checks if proxy options should be added to request.
+     *
+     * @return callable
+     */
+    protected static function add_proxy_when_required(): callable {
+        return function (callable $handler) {
+            return function (RequestInterface $request, array $options) use ($handler) {
+                global $CFG;
+                if (!empty($CFG->proxyhost) && !is_proxybypass((string) $request->getUri())) {
+                    $options['proxy'] = aws_helper::get_proxy_string();
+                }
+                return $handler($request, $options);
+            };
+        };
+    }
+}

--- a/tests/aws_helper_test.php
+++ b/tests/aws_helper_test.php
@@ -38,7 +38,8 @@ class aws_helper_testcase extends \advanced_testcase {
     public function test_get_proxy_string() {
         global $CFG;
         $this->resetAfterTest();
-        // Confirm with no config an emtpy string is returned.
+        // Confirm with no config an empty string is returned.
+        $CFG->proxyhost = '';
         $this->assertEquals('', \local_aws\local\aws_helper::get_proxy_string());
 
         // Now set some configs.

--- a/tests/guzzle_helper_test.php
+++ b/tests/guzzle_helper_test.php
@@ -1,0 +1,135 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_aws;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use local_aws\local\aws_helper;
+use local_aws\local\guzzle_helper;
+
+/**
+ * Test the guzzle_helper class that includes middleware for proxy settings.
+ *
+ * @package    local_aws
+ * @author     Andrew Madden <andrewmadden@catalyst-au.net>
+ * @copyright  2023 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class guzzle_helper_test extends \advanced_testcase {
+
+    /**
+     * This method runs before every test.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+    }
+
+    /**
+     * Test that the Middleware is added to the HandlerStack for the Guzzle client.
+     */
+    public function test_configure_client_proxy_adds_middleware() {
+        // Create client with mock response.
+        $mockhandler = new MockHandler([
+            new Response(200, [], 'Mock response'),
+        ]);
+        $stack = HandlerStack::create($mockhandler);
+        $client = guzzle_helper::configure_client_proxy(new Client(['handler' => $stack]));
+        // Check proxy middleware added to handler stack.
+        $handler = $client->getConfig('handler');
+        if (method_exists($this, 'assertStringContainsString')) {
+            $this->assertStringContainsString("Name: 'proxy'", (string) $handler);
+        } else {
+            // Use earlier alternate method for older PHPUnit versions.
+            $this->assertContains("Name: 'proxy'", (string) $handler);
+        }
+    }
+
+    /**
+     * Test proxy is used for a request.
+     */
+    public function test_configure_client_proxy_with_proxied_request() {
+        global $CFG;
+        // Set default proxy settings.
+        $CFG->proxyhost = 'proxyhost';
+        $CFG->proxyport = 3128;
+        $CFG->proxytype = 'HTTP';
+        $CFG->proxybypass = '';
+
+        // Create client with mock response.
+        $mockhandler = new MockHandler([
+            new Response(200, [], 'Mock response'),
+        ]);
+        $stack = HandlerStack::create($mockhandler);
+        $client = guzzle_helper::configure_client_proxy(new Client(['handler' => $stack]));
+
+        // Check what Middleware is called.
+        $client->request('get', 'http://example.com');
+        $lastrequestoptions = $mockhandler->getLastOptions();
+        $this->assertArrayHasKey('proxy', $lastrequestoptions);
+        $this->assertEquals(aws_helper::get_proxy_string(), $lastrequestoptions['proxy']);
+    }
+
+    /**
+     * Test no proxy used if request is in proxy bypass list.
+     */
+    public function test_configure_client_proxy_with_bypassed_proxied_request() {
+        global $CFG;
+        // Set default proxy settings.
+        $CFG->proxyhost = 'proxyhost';
+        $CFG->proxyport = 3128;
+        $CFG->proxytype = 'HTTP';
+        $CFG->proxybypass = 'example.com';
+
+        // Create client with mock response.
+        $mockhandler = new MockHandler([
+            new Response(200, [], 'Mock response'),
+        ]);
+        $stack = HandlerStack::create($mockhandler);
+        $client = guzzle_helper::configure_client_proxy(new Client(['handler' => $stack]));
+
+        // Check what Middleware is called.
+        $client->request('get', 'http://example.com');
+        $lastrequestoptions = $mockhandler->getLastOptions();
+        $this->assertArrayNotHasKey('proxy', $lastrequestoptions);
+    }
+
+    /**
+     * Test no proxy used if none is configured.
+     */
+    public function test_configure_client_proxy_with_no_proxy_configured() {
+        global $CFG;
+        // Set default proxy settings.
+        $CFG->proxyhost = '';
+        $CFG->proxyport = '';
+        $CFG->proxytype = '';
+        $CFG->proxybypass = '';
+
+        // Create client with mock response.
+        $mockhandler = new MockHandler([
+            new Response(200, [], 'Mock response'),
+        ]);
+        $stack = HandlerStack::create($mockhandler);
+        $client = guzzle_helper::configure_client_proxy(new Client(['handler' => $stack]));
+
+        // Check what Middleware is called.
+        $client->request('get', 'http://example.com');
+        $lastrequestoptions = $mockhandler->getLastOptions();
+        $this->assertArrayNotHasKey('proxy', $lastrequestoptions);
+    }
+}

--- a/version.php
+++ b/version.php
@@ -25,9 +25,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022033100;
+$plugin->version   = 2023010900;
 $plugin->release   = '3.208.1'; // This should be in lock step with sdk/CHANGELOG.md.
 $plugin->requires  = 2013111811;
 $plugin->component = 'local_aws';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->supported = [26, 311]; // A range of branch numbers of supported moodle versions.
+$plugin->supported = [26, 401]; // A range of branch numbers of supported moodle versions.


### PR DESCRIPTION
* Adds middleware that conditionally adds proxy options to REST requests using Guzzle.
* Renamed AWS middleware to be consistent with middleware function describing it's purpose.
* Fixed an aws middleware unit test so that it does not rely on server or application config.