### PR TITLE
Re-instate 'Fix aws library conflicts in Totara'

### DIFF
--- a/sdk/aws-autoloader.php
+++ b/sdk/aws-autoloader.php
@@ -2826,8 +2826,13 @@ spl_autoload_register(function ($class) use ($mapping) {
     }
 }, true);
 
-require __DIR__ . '/Aws/functions.php';
-require __DIR__ . '/GuzzleHttp/functions_include.php';
+if ((!isset($CFG->libraries) && !file_exists($CFG->libraries . '/optional/aws/aws-sdk-php/src/functions.php'))
+    && !function_exists('Aws\constantly'))  {
+    require_once __DIR__ . '/Aws/functions.php';
+}
+if (!function_exists('GuzzleHttp\describe_type')) {
+    require_once __DIR__ . '/GuzzleHttp/functions_include.php';
+}
 require __DIR__ . '/GuzzleHttp/Psr7/functions_include.php';
 require __DIR__ . '/GuzzleHttp/Promise/functions_include.php';
 require __DIR__ . '/JmesPath/JmesPath.php';


### PR DESCRIPTION
This commit is slightly different to the original as we encountered an issue today for a site that had a block that utilises elastic search added to a course page, for which the original fix did not successfully work.

This fix should be slightly more robust in that it checks for optional library file and the function; if those don't exist then it will use the plugin version.