### PR TITLE
Restore sdk intructions

### DIFF
--- a/sdk/readme_moodle.txt
+++ b/sdk/readme_moodle.txt
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Run this script from the sdk folder
+# Update version.php verion and release
+# Manually test that the SDK can be used with no issues.
+
+SDKDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+
+find $SDKDIR -mindepth 1 -maxdepth 1 | grep -v readme_moodle.txt | xargs rm -rf
+wget -O $SDKDIR/sdk.zip "http://docs.aws.amazon.com/aws-sdk-php/v3/download/aws.zip"
+unzip $SDKDIR/sdk.zip -d $SDKDIR
+sed -i -e 's/require/require_once/g' $SDKDIR/aws-autoloader.php
+sed -i -e 's#GuzzleHttp/functions.php#GuzzleHttp/functions_include.php#g' $SDKDIR/aws-autoloader.php
+sed -i -e 's#GuzzleHttp/Psr7/functions.php#GuzzleHttp/Psr7/functions_include.php#g' $SDKDIR/aws-autoloader.php
+sed -i -e 's#GuzzleHttp/Promise/functions.php#GuzzleHttp/Promise/functions_include.php#g' $SDKDIR/aws-autoloader.php
+rm $SDKDIR/sdk.zip
+echo
+echo 'Go update version.php'
+echo $SDKDIR

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023072100;
+$plugin->version   = 2024020600;
 $plugin->release   = '3.276.2'; // This should be in lock step with sdk/CHANGELOG.md.
 $plugin->requires  = 2013111811;
 $plugin->component = 'local_aws';


### PR DESCRIPTION
`sdk/readme_moodle.txt` seems to be deleted as part of the last SDK update, also see https://github.com/catalyst/moodle-local_aws/issues/56#issuecomment-1658144245