### PR TITLE
Fix PSR-7 v2.0 compatibility for systems shipping psr/http-message 2.0

### DIFF
--- a/classes/admin_settings_aws_region.php
+++ b/classes/admin_settings_aws_region.php
@@ -37,7 +37,6 @@ require_once($CFG->dirroot . '/lib/adminlib.php');
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class admin_settings_aws_region extends \admin_setting_configtext {
-
     /**
      * Return part of form with setting.
      *
@@ -45,7 +44,7 @@ class admin_settings_aws_region extends \admin_setting_configtext {
      * @param string $query
      * @return string
      */
-    public function output_html($data, $query='') {
+    public function output_html($data, $query = '') {
         global $CFG;
 
         $default = $this->get_defaultsetting();
@@ -63,7 +62,7 @@ class admin_settings_aws_region extends \admin_setting_configtext {
             }
         }
 
-        $inputparams = array(
+        $inputparams = [
             'type' => 'text',
             'list' => $this->get_full_name(),
             'name' => $this->get_full_name(),
@@ -71,13 +70,13 @@ class admin_settings_aws_region extends \admin_setting_configtext {
             'size' => $this->size,
             'id' => $this->get_id(),
             'class' => 'form-control text-ltr',
-        );
+        ];
 
-        $element = \html_writer::start_tag('div', array('class' => 'form-text defaultsnext'));
+        $element = \html_writer::start_tag('div', ['class' => 'form-text defaultsnext']);
         $element .= \html_writer::empty_tag('input', $inputparams);
-        $element .= \html_writer::start_tag('datalist', array('id' => $this->get_full_name()));
+        $element .= \html_writer::start_tag('datalist', ['id' => $this->get_full_name()]);
         foreach ($options as $option) {
-            $element .= \html_writer::tag('option', $option['label'], array('value' => $option['value']));
+            $element .= \html_writer::tag('option', $option['label'], ['value' => $option['value']]);
         }
         $element .= \html_writer::end_tag('datalist');
         $element .= \html_writer::end_tag('div');

--- a/classes/local/aws_helper.php
+++ b/classes/local/aws_helper.php
@@ -36,7 +36,6 @@ use Psr\Http\Message\RequestInterface;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class aws_helper {
-
     /**
      * This creates a proxy string suitable for use with the AWS SDK.
      *
@@ -57,7 +56,7 @@ class aws_helper {
         if (!empty($CFG->proxyhost)) {
             $proxy = $CFG->proxyhost;
             if (!empty($CFG->proxyport)) {
-                $proxy .= ':'. $CFG->proxyport;
+                $proxy .= ':' . $CFG->proxyport;
             }
             if (!empty($CFG->proxyuser) && !empty($CFG->proxypassword)) {
                 $proxy = $protocol . $CFG->proxyuser . ':' . $CFG->proxypassword . '@' . $proxy;

--- a/classes/local/client_factory.php
+++ b/classes/local/client_factory.php
@@ -24,7 +24,7 @@
  */
 
 namespace local_aws\local;
-use \Aws\AwsClient;
+use Aws\AwsClient;
 
 /**
  * AWS Client factory. Retrieves a client with moodle specific HTTP configuration.

--- a/classes/local/guzzle_helper.php
+++ b/classes/local/guzzle_helper.php
@@ -28,7 +28,6 @@ use Psr\Http\Message\RequestInterface;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class guzzle_helper {
-
     /**
      * Add additional configuration to the Guzzle client. For example, adding additional Middleware.
      *

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -13,6 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Privacy provider.
  *
@@ -24,7 +25,7 @@
 namespace local_aws\privacy;
 
 use core_privacy\local\metadata\null_provider;
-use core_privacy\local\legacy_polyfill;
+
 /**
  * Class provider
  * @author    Ilya Tregubov (ilyatregubov@catalyst-au.net)
@@ -32,14 +33,13 @@ use core_privacy\local\legacy_polyfill;
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider implements null_provider {
-    use legacy_polyfill;
     /**
      * Get the language string identifier with the component's language
      * file to explain why this plugin stores no data.
      *
      * @return  string
      */
-    public static function _get_reason() {
+    public static function get_reason(): string {
         return 'privacy:metadata';
     }
 }

--- a/sdk/Aws/Api/Parser/QueryParser.php
+++ b/sdk/Aws/Api/Parser/QueryParser.php
@@ -19,19 +19,19 @@ class QueryParser extends AbstractParser
     private $honorResultWrapper;
 
     /**
-     * @param Service   $api                Service description
-     * @param XmlParser $xmlParser          Optional XML parser
-     * @param bool      $honorResultWrapper Set to false to disable the peeling
-     *                                      back of result wrappers from the
-     *                                      output structure.
+     * @param Service                          $api                Service description
+     * @param \Aws\Api\Parser\XmlParser $xmlParser          Optional XML parser
+     * @param bool                             $honorResultWrapper Set to false to disable the peeling
+     *                                                            back of result wrappers from the
+     *                                                            output structure.
      */
     public function __construct(
         Service $api,
-        XmlParser $xmlParser = null,
+        \Aws\Api\Parser\XmlParser $xmlParser = null,
         $honorResultWrapper = true
     ) {
         parent::__construct($api);
-        $this->parser = $xmlParser ?: new XmlParser();
+        $this->parser = $xmlParser ?: new \Aws\Api\Parser\XmlParser();
         $this->honorResultWrapper = $honorResultWrapper;
     }
 

--- a/sdk/Aws/Api/Parser/RestXmlParser.php
+++ b/sdk/Aws/Api/Parser/RestXmlParser.php
@@ -14,13 +14,13 @@ class RestXmlParser extends AbstractRestParser
     use PayloadParserTrait;
 
     /**
-     * @param Service   $api    Service description
-     * @param XmlParser $parser XML body parser
+     * @param Service                          $api    Service description
+     * @param \Aws\Api\Parser\XmlParser $parser XML body parser
      */
-    public function __construct(Service $api, XmlParser $parser = null)
+    public function __construct(Service $api, \Aws\Api\Parser\XmlParser $parser = null)
     {
         parent::__construct($api);
-        $this->parser = $parser ?: new XmlParser();
+        $this->parser = $parser ?: new \Aws\Api\Parser\XmlParser();
     }
 
     protected function payload(

--- a/sdk/Aws/Crypto/AesDecryptingStream.php
+++ b/sdk/Aws/Crypto/AesDecryptingStream.php
@@ -65,7 +65,7 @@ class AesDecryptingStream implements AesStreamInterface
         return $this->cipherMethod->getCurrentIv();
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         $plainTextSize = $this->stream->getSize();
 
@@ -80,12 +80,12 @@ class AesDecryptingStream implements AesStreamInterface
         return $plainTextSize;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         if ($length > strlen($this->buffer)) {
             $this->buffer .= $this->decryptBlock(
@@ -101,7 +101,7 @@ class AesDecryptingStream implements AesStreamInterface
         return $data ? $data : '';
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         if ($offset === 0 && $whence === SEEK_SET) {
             $this->buffer = '';

--- a/sdk/Aws/Crypto/AesEncryptingStream.php
+++ b/sdk/Aws/Crypto/AesEncryptingStream.php
@@ -65,7 +65,7 @@ class AesEncryptingStream implements AesStreamInterface
         return $this->cipherMethod->getCurrentIv();
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         $plainTextSize = $this->stream->getSize();
 
@@ -79,12 +79,12 @@ class AesEncryptingStream implements AesStreamInterface
         return $plainTextSize;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         if ($length > strlen($this->buffer)) {
             $this->buffer .= $this->encryptBlock(
@@ -99,7 +99,7 @@ class AesEncryptingStream implements AesStreamInterface
         return $data ? $data : '';
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         if ($whence === SEEK_CUR) {
             $offset = $this->tell() + $offset;

--- a/sdk/Aws/Crypto/AesGcmDecryptingStream.php
+++ b/sdk/Aws/Crypto/AesGcmDecryptingStream.php
@@ -100,7 +100,7 @@ class AesGcmDecryptingStream implements AesStreamInterface
         }
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }

--- a/sdk/Aws/Crypto/AesGcmEncryptingStream.php
+++ b/sdk/Aws/Crypto/AesGcmEncryptingStream.php
@@ -118,7 +118,7 @@ class AesGcmEncryptingStream implements AesStreamInterface, AesStreamInterfaceV2
         return $this->tag;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }

--- a/sdk/Aws/Handler/GuzzleV5/PsrStream.php
+++ b/sdk/Aws/Handler/GuzzleV5/PsrStream.php
@@ -22,12 +22,12 @@ class PsrStream implements Psr7StreamInterface
         $this->stream = $stream;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->stream->seek(0);
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         return $this->stream->getContents();
     }

--- a/sdk/Aws/HashingStream.php
+++ b/sdk/Aws/HashingStream.php
@@ -36,7 +36,7 @@ class HashingStream implements StreamInterface
         $this->callback = $onComplete;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         $data = $this->stream->read($length);
         $this->hash->update($data);
@@ -50,14 +50,15 @@ class HashingStream implements StreamInterface
         return $data;
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         if ($offset === 0) {
             $this->hash->reset();
-            return $this->stream->seek($offset);
+            $this->stream->seek($offset);
+            return;
         }
 
         // Seeking arbitrarily is not supported.
-        return false;
+        throw new \LogicException('Cannot seek to arbitrary positions on a HashingStream');
     }
 }

--- a/sdk/GuzzleHttp/Psr7/AppendStream.php
+++ b/sdk/GuzzleHttp/Psr7/AppendStream.php
@@ -31,7 +31,7 @@ class AppendStream implements StreamInterface
         }
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         try {
             $this->rewind();
@@ -62,7 +62,7 @@ class AppendStream implements StreamInterface
         $this->streams[] = $stream;
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         return Utils::copyToString($this);
     }
@@ -72,7 +72,7 @@ class AppendStream implements StreamInterface
      *
      * {@inheritdoc}
      */
-    public function close()
+    public function close(): void
     {
         $this->pos = $this->current = 0;
         $this->seekable = true;
@@ -105,7 +105,7 @@ class AppendStream implements StreamInterface
         return null;
     }
 
-    public function tell()
+    public function tell(): int
     {
         return $this->pos;
     }
@@ -118,7 +118,7 @@ class AppendStream implements StreamInterface
      *
      * {@inheritdoc}
      */
-    public function getSize()
+    public function getSize(): ?int
     {
         $size = 0;
 
@@ -133,14 +133,14 @@ class AppendStream implements StreamInterface
         return $size;
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return !$this->streams ||
             ($this->current >= count($this->streams) - 1 &&
              $this->streams[$this->current]->eof());
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
@@ -150,7 +150,7 @@ class AppendStream implements StreamInterface
      *
      * {@inheritdoc}
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         if (!$this->seekable) {
             throw new \RuntimeException('This AppendStream is not seekable');
@@ -184,7 +184,7 @@ class AppendStream implements StreamInterface
      *
      * {@inheritdoc}
      */
-    public function read($length)
+    public function read($length): string
     {
         $buffer = '';
         $total = count($this->streams) - 1;
@@ -219,22 +219,22 @@ class AppendStream implements StreamInterface
         return $buffer;
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return true;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return $this->seekable;
     }
 
-    public function write($string)
+    public function write($string): int
     {
         throw new \RuntimeException('Cannot write to an AppendStream');
     }

--- a/sdk/GuzzleHttp/Psr7/BufferStream.php
+++ b/sdk/GuzzleHttp/Psr7/BufferStream.php
@@ -31,12 +31,12 @@ class BufferStream implements StreamInterface
         $this->hwm = $hwm;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getContents();
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         $buffer = $this->buffer;
         $this->buffer = '';
@@ -44,7 +44,7 @@ class BufferStream implements StreamInterface
         return $buffer;
     }
 
-    public function close()
+    public function close(): void
     {
         $this->buffer = '';
     }
@@ -56,42 +56,42 @@ class BufferStream implements StreamInterface
         return null;
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         return strlen($this->buffer);
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return true;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return true;
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return false;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         throw new \RuntimeException('Cannot seek a BufferStream');
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return strlen($this->buffer) === 0;
     }
 
-    public function tell()
+    public function tell(): int
     {
         throw new \RuntimeException('Cannot determine the position of a BufferStream');
     }
@@ -99,7 +99,7 @@ class BufferStream implements StreamInterface
     /**
      * Reads data from the buffer.
      */
-    public function read($length)
+    public function read($length): string
     {
         $currentLength = strlen($this->buffer);
 
@@ -119,7 +119,7 @@ class BufferStream implements StreamInterface
     /**
      * Writes data to the buffer.
      */
-    public function write($string)
+    public function write($string): int
     {
         $this->buffer .= $string;
 

--- a/sdk/GuzzleHttp/Psr7/CachingStream.php
+++ b/sdk/GuzzleHttp/Psr7/CachingStream.php
@@ -34,7 +34,7 @@ class CachingStream implements StreamInterface
         $this->stream = $target ?: new Stream(Utils::tryFopen('php://temp', 'r+'));
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         $remoteSize = $this->remoteStream->getSize();
 
@@ -45,12 +45,12 @@ class CachingStream implements StreamInterface
         return max($this->stream->getSize(), $remoteSize);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         if ($whence == SEEK_SET) {
             $byte = $offset;
@@ -81,7 +81,7 @@ class CachingStream implements StreamInterface
         }
     }
 
-    public function read($length)
+    public function read($length): string
     {
         // Perform a regular read on any previously read data from the buffer
         $data = $this->stream->read($length);
@@ -110,7 +110,7 @@ class CachingStream implements StreamInterface
         return $data;
     }
 
-    public function write($string)
+    public function write($string): int
     {
         // When appending to the end of the currently read stream, you'll want
         // to skip bytes from being read from the remote stream to emulate
@@ -124,7 +124,7 @@ class CachingStream implements StreamInterface
         return $this->stream->write($string);
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return $this->stream->eof() && $this->remoteStream->eof();
     }
@@ -132,7 +132,7 @@ class CachingStream implements StreamInterface
     /**
      * Close both the remote stream and buffer stream
      */
-    public function close()
+    public function close(): void
     {
         $this->remoteStream->close() && $this->stream->close();
     }

--- a/sdk/GuzzleHttp/Psr7/DroppingStream.php
+++ b/sdk/GuzzleHttp/Psr7/DroppingStream.php
@@ -26,7 +26,7 @@ class DroppingStream implements StreamInterface
         $this->maxLength = $maxLength;
     }
 
-    public function write($string)
+    public function write($string): int
     {
         $diff = $this->maxLength - $this->stream->getSize();
 

--- a/sdk/GuzzleHttp/Psr7/FnStream.php
+++ b/sdk/GuzzleHttp/Psr7/FnStream.php
@@ -86,14 +86,14 @@ class FnStream implements StreamInterface
         return new self($methods);
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return call_user_func($this->_fn___toString);
     }
 
-    public function close()
+    public function close(): void
     {
-        return call_user_func($this->_fn_close);
+        call_user_func($this->_fn_close);
     }
 
     public function detach()
@@ -101,57 +101,57 @@ class FnStream implements StreamInterface
         return call_user_func($this->_fn_detach);
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         return call_user_func($this->_fn_getSize);
     }
 
-    public function tell()
+    public function tell(): int
     {
         return call_user_func($this->_fn_tell);
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return call_user_func($this->_fn_eof);
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return call_user_func($this->_fn_isSeekable);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         call_user_func($this->_fn_rewind);
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         call_user_func($this->_fn_seek, $offset, $whence);
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return call_user_func($this->_fn_isWritable);
     }
 
-    public function write($string)
+    public function write($string): int
     {
         return call_user_func($this->_fn_write, $string);
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return call_user_func($this->_fn_isReadable);
     }
 
-    public function read($length)
+    public function read($length): string
     {
         return call_user_func($this->_fn_read, $length);
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         return call_user_func($this->_fn_getContents);
     }

--- a/sdk/GuzzleHttp/Psr7/LimitStream.php
+++ b/sdk/GuzzleHttp/Psr7/LimitStream.php
@@ -36,7 +36,7 @@ class LimitStream implements StreamInterface
         $this->setOffset($offset);
     }
 
-    public function eof()
+    public function eof(): bool
     {
         // Always return true if the underlying stream is EOF
         if ($this->stream->eof()) {
@@ -55,7 +55,7 @@ class LimitStream implements StreamInterface
      * Returns the size of the limited subset of data
      * {@inheritdoc}
      */
-    public function getSize()
+    public function getSize(): ?int
     {
         if (null === ($length = $this->stream->getSize())) {
             return null;
@@ -70,7 +70,7 @@ class LimitStream implements StreamInterface
      * Allow for a bounded seek on the read limited stream
      * {@inheritdoc}
      */
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         if ($whence !== SEEK_SET || $offset < 0) {
             throw new \RuntimeException(sprintf(
@@ -95,7 +95,7 @@ class LimitStream implements StreamInterface
      * Give a relative tell()
      * {@inheritdoc}
      */
-    public function tell()
+    public function tell(): int
     {
         return $this->stream->tell() - $this->offset;
     }
@@ -137,7 +137,7 @@ class LimitStream implements StreamInterface
         $this->limit = $limit;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         if ($this->limit == -1) {
             return $this->stream->read($length);

--- a/sdk/GuzzleHttp/Psr7/MessageTrait.php
+++ b/sdk/GuzzleHttp/Psr7/MessageTrait.php
@@ -21,12 +21,12 @@ trait MessageTrait
     /** @var StreamInterface|null */
     private $stream;
 
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->protocol;
     }
 
-    public function withProtocolVersion($version)
+    public function withProtocolVersion($version): \Psr\Http\Message\MessageInterface
     {
         if ($this->protocol === $version) {
             return $this;
@@ -37,17 +37,17 @@ trait MessageTrait
         return $new;
     }
 
-    public function getHeaders()
+    public function getHeaders(): array
     {
         return $this->headers;
     }
 
-    public function hasHeader($header)
+    public function hasHeader($header): bool
     {
         return isset($this->headerNames[strtolower($header)]);
     }
 
-    public function getHeader($header)
+    public function getHeader($header): array
     {
         $header = strtolower($header);
 
@@ -60,12 +60,12 @@ trait MessageTrait
         return $this->headers[$header];
     }
 
-    public function getHeaderLine($header)
+    public function getHeaderLine($header): string
     {
         return implode(', ', $this->getHeader($header));
     }
 
-    public function withHeader($header, $value)
+    public function withHeader($header, $value): \Psr\Http\Message\MessageInterface
     {
         $this->assertHeader($header);
         $value = $this->normalizeHeaderValue($value);
@@ -81,7 +81,7 @@ trait MessageTrait
         return $new;
     }
 
-    public function withAddedHeader($header, $value)
+    public function withAddedHeader($header, $value): \Psr\Http\Message\MessageInterface
     {
         $this->assertHeader($header);
         $value = $this->normalizeHeaderValue($value);
@@ -99,7 +99,7 @@ trait MessageTrait
         return $new;
     }
 
-    public function withoutHeader($header)
+    public function withoutHeader($header): \Psr\Http\Message\MessageInterface
     {
         $normalized = strtolower($header);
 
@@ -115,7 +115,7 @@ trait MessageTrait
         return $new;
     }
 
-    public function getBody()
+    public function getBody(): \Psr\Http\Message\StreamInterface
     {
         if (!$this->stream) {
             $this->stream = Utils::streamFor('');
@@ -124,7 +124,7 @@ trait MessageTrait
         return $this->stream;
     }
 
-    public function withBody(StreamInterface $body)
+    public function withBody(StreamInterface $body): \Psr\Http\Message\MessageInterface
     {
         if ($body === $this->stream) {
             return $this;

--- a/sdk/GuzzleHttp/Psr7/MultipartStream.php
+++ b/sdk/GuzzleHttp/Psr7/MultipartStream.php
@@ -44,7 +44,7 @@ class MultipartStream implements StreamInterface
         return $this->boundary;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }

--- a/sdk/GuzzleHttp/Psr7/NoSeekStream.php
+++ b/sdk/GuzzleHttp/Psr7/NoSeekStream.php
@@ -13,12 +13,12 @@ class NoSeekStream implements StreamInterface
 {
     use StreamDecoratorTrait;
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         throw new \RuntimeException('Cannot seek a NoSeekStream');
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return false;
     }

--- a/sdk/GuzzleHttp/Psr7/PumpStream.php
+++ b/sdk/GuzzleHttp/Psr7/PumpStream.php
@@ -51,7 +51,7 @@ class PumpStream implements StreamInterface
         $this->buffer = new BufferStream();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         try {
             return Utils::copyToString($this);
@@ -60,7 +60,7 @@ class PumpStream implements StreamInterface
         }
     }
 
-    public function close()
+    public function close(): void
     {
         $this->detach();
     }
@@ -73,52 +73,52 @@ class PumpStream implements StreamInterface
         return null;
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         return $this->size;
     }
 
-    public function tell()
+    public function tell(): int
     {
         return $this->tellPos;
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return !$this->source;
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return false;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         throw new \RuntimeException('Cannot seek a PumpStream');
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }
 
-    public function write($string)
+    public function write($string): int
     {
         throw new \RuntimeException('Cannot write to a PumpStream');
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return true;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         $data = $this->buffer->read($length);
         $readLen = strlen($data);
@@ -134,7 +134,7 @@ class PumpStream implements StreamInterface
         return $data;
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         $result = '';
         while (!$this->eof()) {

--- a/sdk/GuzzleHttp/Psr7/Request.php
+++ b/sdk/GuzzleHttp/Psr7/Request.php
@@ -56,7 +56,7 @@ class Request implements RequestInterface
         }
     }
 
-    public function getRequestTarget()
+    public function getRequestTarget(): string
     {
         if ($this->requestTarget !== null) {
             return $this->requestTarget;
@@ -73,7 +73,7 @@ class Request implements RequestInterface
         return $target;
     }
 
-    public function withRequestTarget($requestTarget)
+    public function withRequestTarget($requestTarget): \Psr\Http\Message\RequestInterface
     {
         if (preg_match('#\s#', $requestTarget)) {
             throw new InvalidArgumentException(
@@ -86,12 +86,12 @@ class Request implements RequestInterface
         return $new;
     }
 
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->method;
     }
 
-    public function withMethod($method)
+    public function withMethod($method): \Psr\Http\Message\RequestInterface
     {
         $this->assertMethod($method);
         $new = clone $this;
@@ -99,12 +99,12 @@ class Request implements RequestInterface
         return $new;
     }
 
-    public function getUri()
+    public function getUri(): \Psr\Http\Message\UriInterface
     {
         return $this->uri;
     }
 
-    public function withUri(UriInterface $uri, $preserveHost = false)
+    public function withUri(UriInterface $uri, $preserveHost = false): \Psr\Http\Message\RequestInterface
     {
         if ($uri === $this->uri) {
             return $this;

--- a/sdk/GuzzleHttp/Psr7/Response.php
+++ b/sdk/GuzzleHttp/Psr7/Response.php
@@ -114,17 +114,17 @@ class Response implements ResponseInterface
         $this->protocol = $version;
     }
 
-    public function getStatusCode()
+    public function getStatusCode(): int
     {
         return $this->statusCode;
     }
 
-    public function getReasonPhrase()
+    public function getReasonPhrase(): string
     {
         return $this->reasonPhrase;
     }
 
-    public function withStatus($code, $reasonPhrase = '')
+    public function withStatus($code, $reasonPhrase = ''): \Psr\Http\Message\ResponseInterface
     {
         $this->assertStatusCodeIsInteger($code);
         $code = (int) $code;

--- a/sdk/GuzzleHttp/Psr7/ServerRequest.php
+++ b/sdk/GuzzleHttp/Psr7/ServerRequest.php
@@ -250,7 +250,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getServerParams()
+    public function getServerParams(): array
     {
         return $this->serverParams;
     }
@@ -258,7 +258,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getUploadedFiles()
+    public function getUploadedFiles(): array
     {
         return $this->uploadedFiles;
     }
@@ -266,7 +266,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withUploadedFiles(array $uploadedFiles)
+    public function withUploadedFiles(array $uploadedFiles): \Psr\Http\Message\ServerRequestInterface
     {
         $new = clone $this;
         $new->uploadedFiles = $uploadedFiles;
@@ -277,7 +277,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getCookieParams()
+    public function getCookieParams(): array
     {
         return $this->cookieParams;
     }
@@ -285,7 +285,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withCookieParams(array $cookies)
+    public function withCookieParams(array $cookies): \Psr\Http\Message\ServerRequestInterface
     {
         $new = clone $this;
         $new->cookieParams = $cookies;
@@ -296,7 +296,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getQueryParams()
+    public function getQueryParams(): array
     {
         return $this->queryParams;
     }
@@ -304,7 +304,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withQueryParams(array $query)
+    public function withQueryParams(array $query): \Psr\Http\Message\ServerRequestInterface
     {
         $new = clone $this;
         $new->queryParams = $query;
@@ -323,7 +323,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withParsedBody($data)
+    public function withParsedBody($data): \Psr\Http\Message\ServerRequestInterface
     {
         $new = clone $this;
         $new->parsedBody = $data;
@@ -334,7 +334,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }
@@ -354,7 +354,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withAttribute($attribute, $value)
+    public function withAttribute($attribute, $value): \Psr\Http\Message\ServerRequestInterface
     {
         $new = clone $this;
         $new->attributes[$attribute] = $value;
@@ -365,7 +365,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     /**
      * {@inheritdoc}
      */
-    public function withoutAttribute($attribute)
+    public function withoutAttribute($attribute): \Psr\Http\Message\ServerRequestInterface
     {
         if (false === array_key_exists($attribute, $this->attributes)) {
             return $this;

--- a/sdk/GuzzleHttp/Psr7/Stream.php
+++ b/sdk/GuzzleHttp/Psr7/Stream.php
@@ -74,7 +74,7 @@ class Stream implements StreamInterface
         $this->close();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         try {
             if ($this->isSeekable()) {
@@ -86,7 +86,7 @@ class Stream implements StreamInterface
         }
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -101,7 +101,7 @@ class Stream implements StreamInterface
         return $contents;
     }
 
-    public function close()
+    public function close(): void
     {
         if (isset($this->stream)) {
             if (is_resource($this->stream)) {
@@ -125,7 +125,7 @@ class Stream implements StreamInterface
         return $result;
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         if ($this->size !== null) {
             return $this->size;
@@ -149,22 +149,22 @@ class Stream implements StreamInterface
         return null;
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return $this->readable;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return $this->writable;
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return $this->seekable;
     }
 
-    public function eof()
+    public function eof(): bool
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -173,7 +173,7 @@ class Stream implements StreamInterface
         return feof($this->stream);
     }
 
-    public function tell()
+    public function tell(): int
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -188,12 +188,12 @@ class Stream implements StreamInterface
         return $result;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         $whence = (int) $whence;
 
@@ -209,7 +209,7 @@ class Stream implements StreamInterface
         }
     }
 
-    public function read($length)
+    public function read($length): string
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');
@@ -233,7 +233,7 @@ class Stream implements StreamInterface
         return $string;
     }
 
-    public function write($string)
+    public function write($string): int
     {
         if (!isset($this->stream)) {
             throw new \RuntimeException('Stream is detached');

--- a/sdk/GuzzleHttp/Psr7/StreamDecoratorTrait.php
+++ b/sdk/GuzzleHttp/Psr7/StreamDecoratorTrait.php
@@ -37,7 +37,7 @@ trait StreamDecoratorTrait
         throw new \UnexpectedValueException("$name not found on class");
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         try {
             if ($this->isSeekable()) {
@@ -52,7 +52,7 @@ trait StreamDecoratorTrait
         }
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         return Utils::copyToString($this);
     }
@@ -73,7 +73,7 @@ trait StreamDecoratorTrait
         return $result === $this->stream ? $this : $result;
     }
 
-    public function close()
+    public function close(): void
     {
         $this->stream->close();
     }
@@ -88,52 +88,52 @@ trait StreamDecoratorTrait
         return $this->stream->detach();
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         return $this->stream->getSize();
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return $this->stream->eof();
     }
 
-    public function tell()
+    public function tell(): int
     {
         return $this->stream->tell();
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return $this->stream->isReadable();
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return $this->stream->isWritable();
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return $this->stream->isSeekable();
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->seek(0);
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         $this->stream->seek($offset, $whence);
     }
 
-    public function read($length)
+    public function read($length): string
     {
         return $this->stream->read($length);
     }
 
-    public function write($string)
+    public function write($string): int
     {
         return $this->stream->write($string);
     }

--- a/sdk/GuzzleHttp/Psr7/UploadedFile.php
+++ b/sdk/GuzzleHttp/Psr7/UploadedFile.php
@@ -231,7 +231,7 @@ class UploadedFile implements UploadedFileInterface
      *
      * @throws RuntimeException if the upload was not successful.
      */
-    public function getStream()
+    public function getStream(): \Psr\Http\Message\StreamInterface
     {
         $this->validateActive();
 
@@ -255,7 +255,7 @@ class UploadedFile implements UploadedFileInterface
      * @throws RuntimeException         on any error during the move operation, or on
      *                                  the second or subsequent call to the method.
      */
-    public function moveTo($targetPath)
+    public function moveTo($targetPath): void
     {
         $this->validateActive();
 
@@ -290,7 +290,7 @@ class UploadedFile implements UploadedFileInterface
      *
      * @return int|null The file size in bytes or null if unknown.
      */
-    public function getSize()
+    public function getSize(): ?int
     {
         return $this->size;
     }
@@ -302,7 +302,7 @@ class UploadedFile implements UploadedFileInterface
      *
      * @return int One of PHP's UPLOAD_ERR_XXX constants.
      */
-    public function getError()
+    public function getError(): int
     {
         return $this->error;
     }
@@ -313,7 +313,7 @@ class UploadedFile implements UploadedFileInterface
      * @return string|null The filename sent by the client or null if none
      *                     was provided.
      */
-    public function getClientFilename()
+    public function getClientFilename(): ?string
     {
         return $this->clientFilename;
     }
@@ -321,7 +321,7 @@ class UploadedFile implements UploadedFileInterface
     /**
      * {@inheritdoc}
      */
-    public function getClientMediaType()
+    public function getClientMediaType(): ?string
     {
         return $this->clientMediaType;
     }

--- a/sdk/GuzzleHttp/Psr7/Uri.php
+++ b/sdk/GuzzleHttp/Psr7/Uri.php
@@ -118,7 +118,7 @@ class Uri implements UriInterface
         return array_map('urldecode', $result);
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return self::composeComponents(
             $this->scheme,
@@ -420,12 +420,12 @@ class Uri implements UriInterface
         return $uri;
     }
 
-    public function getScheme()
+    public function getScheme(): string
     {
         return $this->scheme;
     }
 
-    public function getAuthority()
+    public function getAuthority(): string
     {
         $authority = $this->host;
         if ($this->userInfo !== '') {
@@ -439,37 +439,37 @@ class Uri implements UriInterface
         return $authority;
     }
 
-    public function getUserInfo()
+    public function getUserInfo(): string
     {
         return $this->userInfo;
     }
 
-    public function getHost()
+    public function getHost(): string
     {
         return $this->host;
     }
 
-    public function getPort()
+    public function getPort(): ?int
     {
         return $this->port;
     }
 
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
 
-    public function getQuery()
+    public function getQuery(): string
     {
         return $this->query;
     }
 
-    public function getFragment()
+    public function getFragment(): string
     {
         return $this->fragment;
     }
 
-    public function withScheme($scheme)
+    public function withScheme($scheme): \Psr\Http\Message\UriInterface
     {
         $scheme = $this->filterScheme($scheme);
 
@@ -485,7 +485,7 @@ class Uri implements UriInterface
         return $new;
     }
 
-    public function withUserInfo($user, $password = null)
+    public function withUserInfo($user, $password = null): \Psr\Http\Message\UriInterface
     {
         $info = $this->filterUserInfoComponent($user);
         if ($password !== null) {
@@ -503,7 +503,7 @@ class Uri implements UriInterface
         return $new;
     }
 
-    public function withHost($host)
+    public function withHost($host): \Psr\Http\Message\UriInterface
     {
         $host = $this->filterHost($host);
 
@@ -518,7 +518,7 @@ class Uri implements UriInterface
         return $new;
     }
 
-    public function withPort($port)
+    public function withPort($port): \Psr\Http\Message\UriInterface
     {
         $port = $this->filterPort($port);
 
@@ -534,7 +534,7 @@ class Uri implements UriInterface
         return $new;
     }
 
-    public function withPath($path)
+    public function withPath($path): \Psr\Http\Message\UriInterface
     {
         $path = $this->filterPath($path);
 
@@ -549,7 +549,7 @@ class Uri implements UriInterface
         return $new;
     }
 
-    public function withQuery($query)
+    public function withQuery($query): \Psr\Http\Message\UriInterface
     {
         $query = $this->filterQueryAndFragment($query);
 
@@ -563,7 +563,7 @@ class Uri implements UriInterface
         return $new;
     }
 
-    public function withFragment($fragment)
+    public function withFragment($fragment): \Psr\Http\Message\UriInterface
     {
         $fragment = $this->filterQueryAndFragment($fragment);
 

--- a/sdk/GuzzleHttp/functions_include.php
+++ b/sdk/GuzzleHttp/functions_include.php
@@ -1,6 +1,6 @@
 <?php
 
 // Don't redefine the functions if included multiple times.
-if (!function_exists('GuzzleHttp\uri_template')) {
+if (!function_exists('GuzzleHttp\describe_type')) {
     require __DIR__ . '/functions.php';
 }

--- a/sdk/Symfony/Polyfill/Intl/Idn/bootstrap.php
+++ b/sdk/Symfony/Polyfill/Intl/Idn/bootstrap.php
@@ -126,10 +126,10 @@ if (!defined('IDNA_ERROR_CONTEXTJ')) {
 
 if (PHP_VERSION_ID < 70400) {
     if (!function_exists('idn_to_ascii')) {
-        function idn_to_ascii($domain, $options = IDNA_DEFAULT, $variant = INTL_IDNA_VARIANT_2003, &$idna_info = array()) { return p\Idn::idn_to_ascii($domain, $options, $variant, $idna_info); }
+        function idn_to_ascii($domain, $options = IDNA_DEFAULT, $variant = INTL_IDNA_VARIANT_2003, &$idna_info = array()) { return p\Idn::idn_to_ascii($domain, $options, $variant, $idna_info); } // phpcs:ignore PHPCompatibility.Constants.RemovedConstants.intl_idna_variant_2003Deprecated
     }
     if (!function_exists('idn_to_utf8')) {
-        function idn_to_utf8($domain, $options = IDNA_DEFAULT, $variant = INTL_IDNA_VARIANT_2003, &$idna_info = array()) { return p\Idn::idn_to_utf8($domain, $options, $variant, $idna_info); }
+        function idn_to_utf8($domain, $options = IDNA_DEFAULT, $variant = INTL_IDNA_VARIANT_2003, &$idna_info = array()) { return p\Idn::idn_to_utf8($domain, $options, $variant, $idna_info); } // phpcs:ignore PHPCompatibility.Constants.RemovedConstants.intl_idna_variant_2003Deprecated
     }
 } else {
     if (!function_exists('idn_to_ascii')) {

--- a/tests/admin_settings_aws_region_test.php
+++ b/tests/admin_settings_aws_region_test.php
@@ -35,7 +35,6 @@ namespace local_aws;
  * @covers     \local_aws\admin_settings_aws_region
  */
 class admin_settings_aws_region_test extends \advanced_testcase {
-
     /**
      * Cleanup after all tests are executed.
      *
@@ -50,13 +49,19 @@ class admin_settings_aws_region_test extends \advanced_testcase {
      */
     public function test_output_html() {
         $this->resetAfterTest();
-        $setting = new admin_settings_aws_region('test_aws_region',
-            'Test visible name', 'Test description', 'Test default setting');
+        $setting = new admin_settings_aws_region(
+            'test_aws_region',
+            'Test visible name',
+            'Test description',
+            'Test default setting'
+        );
         $html = $setting->output_html('');
         $this->assertTrue(strpos($html, 'Test visible name') !== false);
         $this->assertTrue(strpos($html, 'Test description') !== false);
         $this->assertTrue(strpos($html, 'Default: Test default setting') !== false);
-        $this->assertTrue(strpos($html, '<input type="text" list="s__test_aws_region" name="s__test_aws_region" value=""') !== false);
+        $this->assertTrue(
+            strpos($html, '<input type="text" list="s__test_aws_region" name="s__test_aws_region" value=""') !== false
+        );
         $this->assertTrue(strpos($html, '<datalist id="s__test_aws_region">') !== false);
         $this->assertTrue(strpos($html, '<option value="') !== false);
     }

--- a/tests/aws_helper_test.php
+++ b/tests/aws_helper_test.php
@@ -37,7 +37,6 @@ use local_aws\local\aws_helper;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class aws_helper_test extends \advanced_testcase {
-
     public function test_get_proxy_string() {
         global $CFG;
         $this->resetAfterTest();
@@ -56,5 +55,4 @@ class aws_helper_test extends \advanced_testcase {
         $CFG->proxytype = 'SOCKS5';
         $this->assertEquals('socks5://user:password@127.0.0.1:1337', aws_helper::get_proxy_string());
     }
-
 }

--- a/tests/guzzle_helper_test.php
+++ b/tests/guzzle_helper_test.php
@@ -37,7 +37,6 @@ use local_aws\local\guzzle_helper;
  * @covers     \local_aws\local\guzzle_helper
  */
 class guzzle_helper_test extends \advanced_testcase {
-
     /**
      * This method runs before every test.
      */


### PR DESCRIPTION
Add return type declarations to all GuzzleHttp\Psr7 classes and AWS SDK stream implementations to match psr/http-message 2.0 interfaces.

Update bundled Psr\Http\Message interfaces to v2.0.

Fix functions_include.php guard to check describe_type instead of uri_template (removed in Guzzle 7) to prevent function redeclaration.

Fixes #78